### PR TITLE
Use multi entry/output config for webpack

### DIFF
--- a/lib/install/webpack/webpack.config.js
+++ b/lib/install/webpack/webpack.config.js
@@ -3,9 +3,11 @@ const webpack = require('webpack')
 
 module.exports = {
   mode: "production",
-  entry: "./app/javascript/application.js",
+  entry: {
+    application: "./app/javascript/application.js"
+  },
   output: {
-    filename: "application.js",
+    filename: "[name].js",
     path: path.resolve(__dirname, "app/assets/builds"),
   },
   plugins: [


### PR DESCRIPTION
Update the default webpack config file to make it more obvious how to have multiple entry/outputs. 
Should ease the migration of existing projects.