### PR TITLE
Depend on railties and sprockets-rails gems instead of rails gem

### DIFF
--- a/jsbundling-rails.gemspec
+++ b/jsbundling-rails.gemspec
@@ -11,5 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*", "MIT-LICENSE", "README.md"]
 
-  spec.add_dependency "rails", ">= 6.0.0"
+  spec.add_dependency "railties", ">= 6.0.0"
+  spec.add_dependency "sprockets-rails", ">= 2.0.0"
 end


### PR DESCRIPTION
Hello,
In my Rails app I don't use the whole Rails  default  stack. I do not have any purpose for ActionMailbox or ActionText inthe application. I still would like to custom my Rails stack with new `jsbundling-rails` gem without forcing me to install these two gems via `rails` gem dependencies.

I think `jsbundling-rails` would only depend on `railties` and `sprockets-rails` gems which are only two major dependencies for it.

Just for curiosity, how I define my custom Rails stack in `Gemfile`:

```ruby
rails_version = '6.1.4.1'

# Custom Rails stack
gem 'railties',      rails_version
gem 'activerecord',  rails_version
gem 'actionpack',    rails_version
gem 'activestorage', rails_version
gem 'actioncable',   rails_version
gem 'actionmailer',  rails_version
```