### PR TITLE
Fallback to `db:test:prepare` when `test:prepare` rake is not found

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -6,4 +6,9 @@ namespace :javascript do
 end
 
 Rake::Task["assets:precompile"].enhance(["javascript:build"])
-Rake::Task["test:prepare"].enhance(["javascript:build"]) if Rake::Task.task_defined?("test:prepare")
+
+if Rake::Task.task_defined?("test:prepare")
+  Rake::Task["test:prepare"].enhance(["javascript:build"])
+elsif Rake::Task.task_defined?("db:test:prepare")
+  Rake::Task["db:test:prepare"].enhance(["javascript:build"])
+end


### PR DESCRIPTION
The rake to prepare rails test in Rails 6 (and below) is `bin/rails db:test:prepare`.