### PR TITLE
Generate source maps and configure digest bypass

### DIFF
--- a/lib/install/webpack/webpack.config.js
+++ b/lib/install/webpack/webpack.config.js
@@ -1,18 +1,15 @@
 const path    = require("path")
-const webpack = require('webpack')
 
 module.exports = {
   mode: "production",
+  devtool: "source-map",
   entry: {
     application: "./app/javascript/application.js"
   },
   output: {
-    filename: "[name].js",
+    filename: '[name].js',
+    chunkFilename: '[name]-[contenthash].digested.js',
+    sourceMapFilename: '[name]-[contenthash].digested.js.map',
     path: path.resolve(__dirname, "app/assets/builds"),
-  },
-  plugins: [
-    new webpack.optimize.LimitChunkCountPlugin({
-      maxChunks: 1
-    })
-  ]
+  }
 }


### PR DESCRIPTION
Depends on https://github.com/rails/sprockets/pull/714

Updates Webpack's config to make it hash any chunk it generates. This causes Sprockets to skip fingerprinting the chunks, and therefore not breaking Webpack features that rely on knowing the chunk's exact name, such as lazy loading:

```js
async bootstrap () {
  const { default: Trix } = await import(/* webpackChunkName: "trix" */ '../../chunks/trix')
  return Trix
}
```

@dhh I've tested this one by creating a new project from the current Rails `main`, and forcing bundler to use the sprockets PR we were discussing, then applying this configuration, and running on production mode. Worked great.
```bash
../rails/railties/exe/rails new mega --dev -j webpack
```
```ruby
gem "sprockets", :git => 'git://github.com/FestaLab/sprockets.git', :branch => 'skip-digested-files'
```

<img width="1018" alt="Screen Shot 2021-09-11 at 18 49 24" src="https://user-images.githubusercontent.com/1793280/132962655-d8324a6b-7117-45b2-8ad2-08521da584ee.png">
