### PR TITLE
Fix Procfile.dev to terminated with a newline

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -28,7 +28,7 @@ unless Rails.root.join("package.json").exist?
 end
 
 if Rails.root.join("Procfile.dev").exist?
-  append_to_file "Procfile.dev", "js: yarn build --watch"
+  append_to_file "Procfile.dev", "js: yarn build --watch\n"
 else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"


### PR DESCRIPTION
Fixed `Procfile.dev` to terminate with a newline when `bin/rails javascript:install:shared` is executed in the presence of `Procfile.dev`.