### PR TITLE
Prevent duplication in gitignore

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -7,7 +7,8 @@ if (sprockets_manifest_path = Rails.root.join("app/assets/config/manifest.js")).
 end
 
 if Rails.root.join(".gitignore").exist?
-  append_to_file(".gitignore", %(\n/app/assets/builds/*\n!/app/assets/builds/.keep\n/node_modules\n))
+  append_to_file(".gitignore", %(\n/app/assets/builds/*\n!/app/assets/builds/.keep\n))
+  append_to_file(".gitignore", %(\n/node_modules\n))
 end
 
 if (app_layout_path = Rails.root.join("app/views/layouts/application.html.erb")).exist?


### PR DESCRIPTION
Also to be consistent with `cssbundling-rails` (See: https://github.com/rails/cssbundling-rails/pull/17#issuecomment-919943813).

Before:

```
/app/assets/builds/*
!/app/assets/builds/.keep

/node_modules

/app/assets/builds/*
!/app/assets/builds/.keep
/node_modules
```

After:

```
/app/assets/builds/*
!/app/assets/builds/.keep

/node_modules
```