### PR TITLE
If build command fails raise a helpful exception

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,7 +1,9 @@
 namespace :javascript do
   desc "Build your JavaScript bundle"
   task :build do
-    system "yarn install && yarn build"
+    unless system "yarn install && yarn build"
+      raise "jsbundling-rails: Command build failed, ensure yarn is installed and `yarn build` runs without errors"
+    end
   end
 end
 


### PR DESCRIPTION
Heroku output:

```
remote: -----> Detecting rake tasks
remote: -----> Preparing app for Rails asset pipeline
remote:        Running: rake assets:precompile
remote:        Yarn executable was not detected in the system.
remote:        Download Yarn at https://yarnpkg.com/en/docs/install
remote:        rake aborted!
remote:        jsbundling-rails: Command build failed, ensure yarn is installed and `yarn build` runs without errors
remote:        /tmp/build_2a1d0ba2/vendor/bundle/ruby/3.0.0/bundler/gems/jsbundling-rails-3d1248a728dd/lib/tasks/jsbundling/build.rake:5:in `block (2 levels) in <main>'
remote:        /tmp/build_2a1d0ba2/vendor/bundle/ruby/3.0.0/gems/sentry-ruby-core-4.7.3/lib/sentry/rake.rb:23:in `block in execute'
remote:        /tmp/build_2a1d0ba2/vendor/bundle/ruby/3.0.0/gems/sentry-ruby-core-4.7.3/lib/sentry/hub.rb:158:in `with_background_worker_disabled'
remote:        /tmp/build_2a1d0ba2/vendor/bundle/ruby/3.0.0/gems/sentry-ruby-core-4.7.3/lib/sentry/rake.rb:22:in `execute'
remote:        Tasks: TOP => assets:precompile => javascript:build
remote:        (See full trace by running task with --trace)
remote: 
remote:  !
remote:  !     Precompiling assets failed.
remote:  !
remote:  !     Push rejected, failed to compile Ruby app.
remote: 
remote:  !     Push failed
remote: Verifying deploy...
remote: 
remote: !       Push rejected to anthem-test.
remote: 
To https://git.heroku.com/anthem-test.git
 ! [remote rejected] main -> main (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/anthem-test.git'
```