### PR TITLE
Add meaningful error message when NPX < 7.1

### DIFF
--- a/lib/install/esbuild/install.rb
+++ b/lib/install/esbuild/install.rb
@@ -1,3 +1,11 @@
+stdout, _stderr, _status = Open3.capture3("npx -v")
+npx_version = stdout.match(/\d.\d+/).to_s.to_f
+
+if npx_version < 7.1
+  say "Failed. Upgrade npx to version 7.1 or later and run install script again", :red
+  abort
+end
+
 say "Install esbuild"
 run "yarn add esbuild"
 

--- a/lib/install/rollup/install.rb
+++ b/lib/install/rollup/install.rb
@@ -1,3 +1,11 @@
+stdout, _stderr, _status = Open3.capture3("npx -v")
+npx_version = stdout.match(/\d.\d+/).to_s.to_f
+
+if npx_version < 7.1
+  say "Failed. Upgrade npx to version 7.1 or later and run install script again", :red
+  abort
+end
+
 say "Install rollup with config"
 copy_file "#{__dir__}/rollup.config.js", "rollup.config.js"
 run "yarn add rollup @rollup/plugin-node-resolve"

--- a/lib/install/webpack/install.rb
+++ b/lib/install/webpack/install.rb
@@ -1,3 +1,11 @@
+stdout, _stderr, _status = Open3.capture3("npx -v")
+npx_version = stdout.match(/\d.\d+/).to_s.to_f
+
+if npx_version < 7.1
+  say "Failed. Upgrade npx to version 7.1 or later and run install script again", :red
+  abort
+end
+
 say "Install Webpack with config"
 copy_file "#{__dir__}/webpack.config.js", "webpack.config.js"
 run "yarn add webpack webpack-cli"


### PR DESCRIPTION
Fixes #35.

Initially, my idea was to add the check (NPX < 7.1) at the beginning of file `lib/install/install.rb`. However the abort command would not exist the program completly and still run the nested install.rb file in `/esbuild`, `/rollup`, or `/webpack` afterwards.  Is there a way to make __abort__ exit the program completely?

This PR  adds a check in each nested install.rb file. Although, the first part of the script executes already it doesn't create any problems when the install script is being re-run after upgrading NPX (>7.1).

Installing `jsbundling-rails` will now return a meaningful error message when NPX < 7.1:
__Failed. Upgrade npx to version 7.1 or later and run install script again__

<img width="525" alt="CleanShot 2021-09-28 at 19 24 45@2x" src="https://user-images.githubusercontent.com/36309895/135144338-10bf929e-84f9-44f8-bc35-b6973e8f689a.png">

