### PR TITLE
Depend on existing yarn:install rake task

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,7 +1,7 @@
 namespace :javascript do
   desc "Build your JavaScript bundle"
   task :build do
-    unless system "yarn install && yarn build"
+    unless system "yarn build"
       raise "jsbundling-rails: Command build failed, ensure yarn is installed and `yarn build` runs without errors"
     end
   end
@@ -13,4 +13,8 @@ if Rake::Task.task_defined?("test:prepare")
   Rake::Task["test:prepare"].enhance(["javascript:build"])
 elsif Rake::Task.task_defined?("db:test:prepare")
   Rake::Task["db:test:prepare"].enhance(["javascript:build"])
+end
+
+if Rake::Task.task_defined?("yarn:install")
+  Rake::Task["javascript:build"].enhance(["yarn:install"])
 end


### PR DESCRIPTION
After migrating to jsbundling-rails, we saw that `yarn:install` ran twice on `rake:assets` precompile.

On a fresh install of rails [`assets:precompile` declares `yarn:install` as a prereq](https://github.com/rails/rails/blob/main/railties/lib/rails/tasks/yarn.rake#L33). But then instead of depending on `yarn:install`, this new `javascript:build` task executes `yarn install` it internally.

This PR establishes the correct dependency using `rake`. If `yarn:install` was never defined, this task will continue to fail with the same error message as before.