### PR TITLE
rename `javascript:` namespace to `js:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Use [esbuild](https://esbuild.github.io), [rollup.js](https://rollupjs.org), or 
 
 You develop using this approach by running the bundler in watch mode in a terminal with `yarn build --watch` (and your Rails server in another, if you're not using something like [puma-dev](https://github.com/puma/puma-dev)). Whenever the bundler detects changes to any of the JavaScript files in your project, it'll bundle `app/javascript/application.js` into `app/assets/builds/application.js` (and all other entry points configured). You can refer to the build output in your layout using the standard asset pipeline approach with `<%= javascript_include_tag "application", defer: true %>`.
 
-When you deploy your application to production, the `javascript:build` task attaches to the `assets:precompile` task to ensure that all your package dependencies from `package.json` have been installed via yarn, and then runs `yarn build` to process all the entry points, as it would in development. The latter files are then picked up by the asset pipeline, digested, and copied into public/assets, as any other asset pipeline file.
+When you deploy your application to production, the `js:build` task attaches to the `assets:precompile` task to ensure that all your package dependencies from `package.json` have been installed via yarn, and then runs `yarn build` to process all the entry points, as it would in development. The latter files are then picked up by the asset pipeline, digested, and copied into public/assets, as any other asset pipeline file.
 
 This also happens in testing where the bundler attaches to the `test:prepare` task to ensure the JavaScript has been bundled before testing commences. (Note that this currently only applies to rails `test:*` tasks (like `test:all` or `test:controllers`), not "rails test", as that doesn't load `test:prepare`).
 
-If your testing library of choice does not define a `test:prepare` Rake task, ensure that your test suite runs `javascript:build` to bundle JavaScript before testing commences.
+If your testing library of choice does not define a `test:prepare` Rake task, ensure that your test suite runs `js:build` to bundle JavaScript before testing commences.
 
 That's it!
 
@@ -23,7 +23,7 @@ You must already have node and yarn installed on your system. You will also need
 
 1. Add `jsbundling-rails` to your Gemfile with `gem 'jsbundling-rails'`
 2. Run `./bin/bundle install`
-3. Run `./bin/rails javascript:install:[esbuild|rollup|webpack]`
+3. Run `./bin/rails js:install:[esbuild|rollup|webpack]`
 
 Or, in Rails 7+, you can preconfigure your new application to use a specific bundler with `rails new myapp -j [esbuild|rollup|webpack]`.
 

--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,4 +1,4 @@
-namespace :javascript do
+namespace :js do
   desc "Build your JavaScript bundle"
   task :build do
     unless system "yarn install && yarn build"
@@ -7,10 +7,10 @@ namespace :javascript do
   end
 end
 
-Rake::Task["assets:precompile"].enhance(["javascript:build"])
+Rake::Task["assets:precompile"].enhance(["js:build"])
 
 if Rake::Task.task_defined?("test:prepare")
-  Rake::Task["test:prepare"].enhance(["javascript:build"])
+  Rake::Task["test:prepare"].enhance(["js:build"])
 elsif Rake::Task.task_defined?("db:test:prepare")
-  Rake::Task["db:test:prepare"].enhance(["javascript:build"])
+  Rake::Task["db:test:prepare"].enhance(["js:build"])
 end

--- a/lib/tasks/jsbundling/clean.rake
+++ b/lib/tasks/jsbundling/clean.rake
@@ -1,8 +1,8 @@
-namespace :javascript do
+namespace :js do
   desc "Remove JavaScript builds"
   task :clean do
     rm_rf Dir["app/assets/builds/[^.]*.js"], verbose: false
   end
 end
 
-Rake::Task["assets:clean"].enhance(["javascript:clean"])
+Rake::Task["assets:clean"].enhance(["js:clean"])

--- a/lib/tasks/jsbundling/install.rake
+++ b/lib/tasks/jsbundling/install.rake
@@ -1,4 +1,4 @@
-namespace :javascript do
+namespace :js do
   namespace :install do
     desc "Install shared elements for all bundlers"
     task :shared do


### PR DESCRIPTION
aligned with cssbundling-rails's css namespace and closer to usage, see https://github.com/rails/rails/pull/43563