### PR TITLE
Make javascript:build depend on yarn:install directly

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,6 +1,6 @@
 namespace :javascript do
   desc "Build your JavaScript bundle"
-  task :build do
+  task build: [ "yarn:install" ] do
     unless system "yarn build"
       raise "jsbundling-rails: Command build failed, ensure yarn is installed and `yarn build` runs without errors"
     end
@@ -13,8 +13,4 @@ if Rake::Task.task_defined?("test:prepare")
   Rake::Task["test:prepare"].enhance(["javascript:build"])
 elsif Rake::Task.task_defined?("db:test:prepare")
   Rake::Task["db:test:prepare"].enhance(["javascript:build"])
-end
-
-if Rake::Task.task_defined?("yarn:install")
-  Rake::Task["javascript:build"].enhance(["yarn:install"])
 end


### PR DESCRIPTION
This updates #43 to depend on `yarn:install` directly instead of as a conditional enhancement.

On my system, I found that jsbundling-rails's build.rake was loading prior to railties' yarn.rake, causing the enhancement to be skipped.
In a way, this was favorable as `yarn:install` relies on `bin/yarn`, which is no longer added in new Rails 7 apps. PR rails/rails#43641 has been opened to address that issue.

I believe it's safe to depend on `yarn:install` directly because jsbundling-rails already depends on railties, so `yarn:install` should always be available. If this somehow isn't valid, then we could add a no-op version of `yarn:install` here which would at least avoid errors while also not skipping enhancement as the existing approach does.