### PR TITLE
Enable sourcemaps by default

### DIFF
--- a/lib/install/esbuild/install.rb
+++ b/lib/install/esbuild/install.rb
@@ -2,7 +2,7 @@ say "Install esbuild"
 run "yarn add esbuild"
 
 say "Add build script"
-build_script = "esbuild app/javascript/*.* --bundle --outdir=app/assets/builds"
+build_script = "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
   say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green

--- a/lib/install/rollup/rollup.config.js
+++ b/lib/install/rollup/rollup.config.js
@@ -5,7 +5,8 @@ export default {
   output: {
     file: "app/assets/builds/application.js",
     format: "es",
-    inlineDynamicImports: true
+    inlineDynamicImports: true,
+    sourcemap: true
   },
   plugins: [
     resolve()

--- a/lib/install/webpack/webpack.config.js
+++ b/lib/install/webpack/webpack.config.js
@@ -3,11 +3,13 @@ const webpack = require("webpack")
 
 module.exports = {
   mode: "production",
+  devtool: "source-map",
   entry: {
     application: "./app/javascript/application.js"
   },
   output: {
     filename: "[name].js",
+    sourceMapFilename: "[name].js.map",
     path: path.resolve(__dirname, "app/assets/builds"),
   },
   plugins: [

--- a/lib/install/webpack/webpack.config.js
+++ b/lib/install/webpack/webpack.config.js
@@ -1,5 +1,5 @@
 const path    = require("path")
-const webpack = require('webpack')
+const webpack = require("webpack")
 
 module.exports = {
   mode: "production",


### PR DESCRIPTION
[sprockets-rails 3.4.0](https://github.com/rails/sprockets-rails/releases/tag/v3.4.0) can now deal with source maps generated by transpilers, so we can enable this feature by default.