### PR TITLE
Stop enhancing rake assets:clean with rake javascript:clean

### DIFF
--- a/lib/tasks/jsbundling/clean.rake
+++ b/lib/tasks/jsbundling/clean.rake
@@ -4,5 +4,3 @@ namespace :javascript do
     rm_rf Dir["app/assets/builds/[^.]*.js"], verbose: false
   end
 end
-
-Rake::Task["assets:clean"].enhance(["javascript:clean"])


### PR DESCRIPTION
See #51 

rake assets:clean is supposed to clean old entries in the public folder, which is not compatible with what rake javascript:clean is doing at the moment