### PR TITLE
Bypass CLI options to Foreman in bin/dev

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -6,4 +6,4 @@ then
   gem install foreman
 fi
 
-foreman start -f Procfile.dev
+foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
This tiny change allows passing foreman options when running `bin/dev`. The most common use case is excluding some processes (eg `web` or `worker`) when you want to debug them:
```
bin/dev all=1,web=0
```