### PR TITLE
Fix doc Switch from Webpacker

### DIFF
--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -61,7 +61,7 @@ If you would like to minimize the diff between Webpacker and jsbundling-rails:
 
 ```diff
 # Remove from your Gemfile
-- gem 'jsbundling-rails'
+- gem 'webpacker'
 ```
 
 3. Run `./bin/bundle install`


### PR DESCRIPTION
I think people should remove `webpacker`, not `jsbundling-rails` 🙂