### PR TITLE
Check assets:precompile and assets:clobber are defined before enhancing

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -7,7 +7,9 @@ namespace :javascript do
   end
 end
 
-Rake::Task["assets:precompile"].enhance(["javascript:build"])
+if Rake::Task.task_defined?("assets:precompile")
+  Rake::Task["assets:precompile"].enhance(["javascript:build"])
+end
 
 if Rake::Task.task_defined?("test:prepare")
   Rake::Task["test:prepare"].enhance(["javascript:build"])

--- a/lib/tasks/jsbundling/clobber.rake
+++ b/lib/tasks/jsbundling/clobber.rake
@@ -5,4 +5,6 @@ namespace :javascript do
   end
 end
 
-Rake::Task["assets:clobber"].enhance(["javascript:clobber"])
+if Rake::Task.task_defined?("assets:clobber")
+  Rake::Task["assets:clobber"].enhance(["javascript:clobber"])
+end


### PR DESCRIPTION
As "Sprockets is not a dependency", we should not
assume that the assets:precompile AND assets:clobber tasks will be defined. If it's not
there, we should just skip enhancing it.

cc @dhh 