### PR TITLE
Fix "Compare With Webpacker" link

### DIFF
--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -1,6 +1,6 @@
 # Switch from Webpacker 5 to jsbundling-rails with webpack
 
-This guide provides step-by-step instructions to migration from [`Webpacker 5`](https://github.com/rails/webpacker/tree/5-x-stable) to `jsbundling-rails` with [`webpack 4`](https://v4.webpack.js.org/concepts/). For upgrading to Webpacker 6 instead, follow [this guide](https://github.com/rails/webpacker/blob/master/docs/v6_upgrade.md) or for comparison between Webpacker and jsbundling-rails, [see this](./docs/comparison_with_webpacker.md).
+This guide provides step-by-step instructions to migration from [`Webpacker 5`](https://github.com/rails/webpacker/tree/5-x-stable) to `jsbundling-rails` with [`webpack 4`](https://v4.webpack.js.org/concepts/). For upgrading to Webpacker 6 instead, follow [this guide](https://github.com/rails/webpacker/blob/master/docs/v6_upgrade.md) or for comparison between Webpacker and jsbundling-rails, [see this](./comparison_with_webpacker.md).
 
 ## 1. Setup jsbundling-rails
 


### PR DESCRIPTION
The "Switch From Webpacker" doc has a link to the "Comparison With Webpacker" doc that isn't working because the generated link includes `/docs/docs` twice.  Since both files are in the docs folder, the link doesn't need to include `docs`. This PR removes `docs` so the link will work.  

Before | After
--- | --- 
![docs-before](https://user-images.githubusercontent.com/373703/150343647-4fca7537-f341-435a-9638-bb3079cf5c7a.jpg) | ![docs-after](https://user-images.githubusercontent.com/373703/150343658-c5cc733e-9d67-4987-9dbd-ebcc45b28489.jpg)

