### PR TITLE
Use webpack-remove-empty-scripts plugin instead of webpack-fix-style-…

### DIFF
--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -181,9 +181,8 @@ yarn add css-loader sass sass-loader mini-css-extract-plugin webpack-fix-style-o
 
 // Extracts CSS into .css file
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-// Removes exported JavaScript files from CSS-only entries
-// in this example, entry.custom will create a corresponding empty custom.js file
-const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+// The plugin removes empty js scripts generated when using only the styles like css scss sass less stylus in the webpack entry.
+const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 
 module.exports = {
   entry: {
@@ -209,7 +208,7 @@ module.exports = {
   },
   plugins: [
     // Include plugins
-    new FixStyleOnlyEntriesPlugin(),
+    new RemoveEmptyScriptsPlugin(),
     new MiniCssExtractPlugin(),
   ],
 };


### PR DESCRIPTION
The webpack-fix-style-only-entries plugin is not compatible with webpack v5.  The webpack-remove-empty-scripts plugin should be used instead

See the repo for details:
https://github.com/webdiscus/webpack-remove-empty-scripts

Using the older webpack-fix-style-only-entries results in errors such as:
```
Module.entryModule: Multiple entry modules are not supported by the deprecated API (Use the new ChunkGroup API)
Error: Module.entryModule: Multiple entry modules are not supported by the deprecated API (Use the new ChunkGroup API)
```