### PR TITLE
Webpack config tweak: name output sourcemaps after the output file with ext.

### DIFF
--- a/lib/install/webpack/webpack.config.js
+++ b/lib/install/webpack/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   output: {
     filename: "[name].js",
-    sourceMapFilename: "[name].js.map",
+    sourceMapFilename: "[file].map",
     path: path.resolve(__dirname, "app/assets/builds"),
   },
   plugins: [


### PR DESCRIPTION
The following is a proposed change that could make the default webpack config slightly more generic.

It is a small tweak to the installed config that changes the [`sourceMapFilename`](https://webpack.js.org/configuration/output/#outputsourcemapfilename) template to `[file].map`. 

This makes things easier if the config is expanded to include css extraction say.

For example, if `mini-css-extract-plugin` is used with `css-loader` / `sass-loader` then the resulting source map is named correctly (`application.css.map` for example) without having to realise/remember the `sourceMapFilename` needs changing.