### PR TITLE
Change Package Manager to NPM

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,8 +1,8 @@
 namespace :javascript do
   desc "Build your JavaScript bundle"
   task :build do
-    unless system "yarn install && yarn build"
-      raise "jsbundling-rails: Command build failed, ensure yarn is installed and `yarn build` runs without errors"
+    unless system "npm install && npm run build"
+      raise "jsbundling-rails: Command build failed, ensure npm is installed and `npm run build` runs without errors"
     end
   end
 end


### PR DESCRIPTION
## Description

- Add Npm as package manager.
- npm install will get used while assest:precompile.