### PR TITLE
Documentation: don't recommend moduleIds: "hashed"

### DIFF
--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -274,7 +274,7 @@ module.exports = {
 -  devtool: "source-map",
   …
 +  optimization: {
-+    moduleIds: mode === 'development' ? 'named' : 'deterministic',
++    moduleIds: 'deterministic',
 +  }
 }
 ```

--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -274,7 +274,7 @@ module.exports = {
 -  devtool: "source-map",
   …
 +  optimization: {
-+    moduleIds: 'hashed',
++    moduleIds: mode === 'development' ? 'named' : 'deterministic',
 +  }
 }
 ```


### PR DESCRIPTION
Using this value gives the warning:

> The value 'hashed' for option 'optimization.moduleIds' is deprecated. Use 'deterministic' instead.

This has been deprecated in https://github.com/webpack/webpack/commit/7669104f7104043b70161f940e0e16b067e02c4b (v5.0.0-alpha.0).

Instead, `deterministic` outputs files like "d85f1fc319f409998963.png" (great for production).

There's also `moduleIds: "named" but it doesn't seem to do anything different.