### PR TITLE
Webpacker instructions: fix incompatibility with Webpack 5

### DIFF
--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -168,7 +168,7 @@ With the right loaders, webpack can handle CSS files. This setup _only_ uses jsb
 
 ```sh
 # From the CLI, add loaders, plugins, and node sass
-yarn add css-loader sass sass-loader mini-css-extract-plugin webpack-fix-style-only-entries
+yarn add css-loader sass sass-loader mini-css-extract-plugin webpack-remove-empty-scripts
 ```
 
 2. Configure webpack
@@ -180,7 +180,7 @@ yarn add css-loader sass sass-loader mini-css-extract-plugin webpack-fix-style-o
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 // Removes exported JavaScript files from CSS-only entries
 // in this example, entry.custom will create a corresponding empty custom.js file
-const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 
 module.exports = {
   entry: {
@@ -206,7 +206,7 @@ module.exports = {
   },
   plugins: [
     // Include plugins
-    new FixStyleOnlyEntriesPlugin(),
+    new RemoveEmptyScriptsPlugin(),
     new MiniCssExtractPlugin(),
   ],
 };


### PR DESCRIPTION
This updates the docs to not suggest a Webpack 4 plugin (webpack-fix-style-only-entries) for a Webpack 5 setup.

## Background

The [webpack-fix-style-only-entries](https://github.com/fqborges/webpack-fix-style-only-entries) recommended by the guide is not compatible with Webpack 5. Another plugin, [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts), is a drop-in replacement that works on Webpack 5.

## Screenshots

This is what happens with webpack-fix-style-only-entries:

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/74385/162880447-64ee681f-6bb2-4a44-92d4-c775da898ffa.png">

This is the notice on the webpack-fix-style-only-entries repo:

<img width="715" alt="image" src="https://user-images.githubusercontent.com/74385/162880311-bffd2a13-38e4-4125-99e6-8c5767fdaefb.png">
