### PR TITLE
Instead of forcing a port in Procfile, unset Foremans's PORT

### DIFF
--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server -p 3000
+web: unset PORT && bin/rails server
 js: yarn build --watch


### PR DESCRIPTION
Foreman sets the PORT environment variable to 5000 by default