### PR TITLE
Fix for foreman existence test in rbenv installs.

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ! command -v foreman &> /dev/null
+if ! foreman version &> /dev/null
 then
   echo "Installing foreman..."
   gem install foreman


### PR DESCRIPTION
Because rbenv uses shims, the existence of foreman in any gemset will result in this test passing (indicating that the tool is available), whether it's in the current gemset or not.

This test, courtesy of @t27duck, ensures that foreman is actually operable in the current context.

This commit mirrors the identical commit in cssbundling-rails:

https://github.com/rails/cssbundling-rails/pull/91/commits/dff88451bfaa4385c3c70b4bca41a11682b173f6