### PR TITLE
Use ruby command "gem list" for foreman existence test

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-if ! foreman version &> /dev/null
-then
+if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi


### PR DESCRIPTION
Hi,
I know this does not solve any current problem, but maybe would be better to use the command [`gem list`](https://guides.rubygems.org/command-reference/#gem-list) to check for foreman.  This command gives a better output (boolean) and appropriate exit code.

Thanks

PS: I have also suggested it for [`cssbundling-rails`](https://github.com/rails/cssbundling-rails/pull/93)