### PR TITLE
Fix deprecated option `hashed`

### DIFF
--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -274,7 +274,7 @@ module.exports = {
 -  devtool: "source-map",
   …
 +  optimization: {
-+    moduleIds: 'hashed',
++    moduleIds: 'deterministic',
 +  }
 }
 ```


### PR DESCRIPTION
From the logs:

```
WARNING in configuration
The value 'hashed' for option 'optimization.moduleIds' is deprecated. Use 'deterministic' instead.
```