### PR TITLE
Update Docs/Example: Include *.css files in css-loader regex

### DIFF
--- a/docs/switch_from_webpacker.md
+++ b/docs/switch_from_webpacker.md
@@ -195,7 +195,7 @@ module.exports = {
     rules: [
       // Add CSS/SASS/SCSS rule with loaders
       {
-        test: /\.s[ac]ss$/i,
+        test: /\.(?:sa|sc|c)ss$/i,
         use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
       },
     ],


### PR DESCRIPTION
Current regex does not include *.css files.