### PR TITLE
Handle subdirectories when building with esbuild

### DIFF
--- a/lib/install/esbuild/install.rb
+++ b/lib/install/esbuild/install.rb
@@ -1,8 +1,9 @@
 say "Install esbuild"
+copy_file "#{__dir__}/tsconfig.json", "tsconfig.json"
 run "yarn add esbuild"
 
 say "Add build script"
-build_script = "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets"
+build_script = "esbuild \`find app/javascript -type f\` --tsconfig=./tsconfig.json --bundle --sourcemap --outdir=app/assets/builds --public-path=assets"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
   say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green

--- a/lib/install/esbuild/tsconfig.json
+++ b/lib/install/esbuild/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "app/javascript"
+  }
+}


### PR DESCRIPTION
This would fix some issues I encountered in #124 when migrating a codebase with subdirectories of JavaScript from Rails 6.1 webpacker -> Rails 7 JS Bundling + esbuild