### PR TITLE
Recursively remove JavaScript builds in clobber task

### DIFF
--- a/lib/tasks/jsbundling/clobber.rake
+++ b/lib/tasks/jsbundling/clobber.rake
@@ -1,7 +1,7 @@
 namespace :javascript do
   desc "Remove JavaScript builds"
   task :clobber do
-    rm_rf Dir["app/assets/builds/[^.]*.{js,js.map}"], verbose: false
+    rm_rf Dir["app/assets/builds/**/[^.]*.{js,js.map}"], verbose: false
   end
 end
 


### PR DESCRIPTION
Handles builds where there are subdirectories of JavaScript