### PR TITLE
Enhance spec:prepare command with JS build

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -13,6 +13,8 @@ end
 
 if Rake::Task.task_defined?("test:prepare")
   Rake::Task["test:prepare"].enhance(["javascript:build"])
+elsif Rake::Task.task_defined?("spec:prepare")
+  Rake::Task["spec:prepare"].enhance(["javascript:build"])
 elsif Rake::Task.task_defined?("db:test:prepare")
   Rake::Task["db:test:prepare"].enhance(["javascript:build"])
 end


### PR DESCRIPTION
For projects using RSpec, the `javascript:build` task isn't appended to the test preparation task, since RSpec uses a [`spec` namespace](https://github.com/rspec/rspec-rails/blob/main/lib/rspec/rails/tasks/rspec.rake#L22). To avoid having to call the enhance method in the project Rakefile, I think it would make sense to have it in here.