### PR TITLE
exec foreman to replace current process

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 if ! gem list foreman -i --silent; then
   echo "Installing foreman..."

--- a/lib/install/dev
+++ b/lib/install/dev
@@ -5,4 +5,4 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
-foreman start -f Procfile.dev "$@"
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Use `exec` to invoke `foreman` to make sure `bin/dev` is replaced by the `foreman` process. This ensures that `foreman` gets `bin/dev`'s pid (so it's cleaned up properly) and that interrupts and signals (like `ctrl+c`) are handled correctly by `foreman` (to shut down child processes).