### PR TITLE
Resolve breaking change in Rollup v3

### DIFF
--- a/lib/install/rollup/install.rb
+++ b/lib/install/rollup/install.rb
@@ -3,7 +3,7 @@ copy_file "#{__dir__}/rollup.config.js", "rollup.config.js"
 run "yarn add rollup @rollup/plugin-node-resolve"
 
 say "Add build script"
-build_script = "rollup -c rollup.config.js"
+build_script = "rollup -c --bundleConfigAsCjs rollup.config.js"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
   say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green

--- a/lib/jsbundling/version.rb
+++ b/lib/jsbundling/version.rb
@@ -1,3 +1,3 @@
 module Jsbundling
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
Rollup has just pushed a major release. (Currently 3.0.1)

This update implements a change for rollup.config.js which requires that it conform to a module to continue use of 'import'. New apps to run `javascript:install:rollup` pull this latest version but use a (now) broken rollup.config.js. 

This triggers unhelpful errors during install.

A flag can be used to bypass the new module requirement.  
See: https://rollupjs.org/guide/en/#--bundleconfigascjs

This PR implements the latter solution as a **_temporary fix_** until someone can formally review how the new convention used in rollup.config.js affects rails apps.