### PR TITLE
Use iife format for Rollup

### DIFF
--- a/lib/install/rollup/rollup.config.js
+++ b/lib/install/rollup/rollup.config.js
@@ -4,7 +4,7 @@ export default {
   input: "app/javascript/application.js",
   output: {
     file: "app/assets/builds/application.js",
-    format: "es",
+    format: "iife",
     inlineDynamicImports: true,
     sourcemap: true
   },


### PR DESCRIPTION
Currently, both esbuild and Webpack output a self-executing function.

```javascript
(() => {
  // code
})();
```

This PR updates Rollup to do the same.

```javascript
(function () {
  // code
})();
```

With the current `es` format, Rollup can set a lot of variables and functions on the `window` object. You can see this with the `chart.js` package and the following `application.js`:

```javascript
import { Chart } from "chart.js/auto"

window.Chart = Chart
```

With esbuild and Webpack, this only sets an additional `Chart` variable on `window`. With Rollup, it sets 400+ more properties.

```javascript
Object.keys(window).length
```