### PR TITLE
Run the server with remote debugging enabled

### DIFF
--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
-web: unset PORT && bin/rails server
+web: unset PORT && env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch


### PR DESCRIPTION
When running inside foreman the 'debug' gem will not have a proper TTY available. 

Running with the `--open` option enabled allows to start remote sessions and attach a debugger client with `rdbg --attach`.

See https://github.com/ruby/debug#invoke-as-a-remote-debuggee.

_I'll open submit the same change to cssbundling-rails once accepted/merged._