### PR TITLE
Support environment variable to skip Yarn install

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,10 +1,18 @@
 namespace :javascript do
-  desc "Build your JavaScript bundle"
-  task :build do
-    unless system "yarn install && yarn build"
-      raise "jsbundling-rails: Command build failed, ensure yarn is installed and `yarn build` runs without errors"
+  desc "Install JavaScript dependencies"
+  task :install do
+    unless system "yarn install"
+      raise "jsbundling-rails: Command install failed, ensure yarn is installed"
     end
   end
+
+  desc "Build your JavaScript bundle"
+  build_task = task :build do
+    unless system "yarn build"
+      raise "jsbundling-rails: Command build failed, ensure `yarn build` runs without errors"
+    end
+  end
+  build_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"]
 end
 
 if Rake::Task.task_defined?("assets:precompile")


### PR DESCRIPTION
Closes #130

These changes allow a project to skip the `yarn install` prestep of the JavaScript build if, for example, their build pipeline will already ensure that dependencies have been installed.

Open question: Should this logic be contained to the existing `build` task, rather than spun out as a new prerequisite task as proposed?