### PR TITLE
Docs typo fix

### DIFF
--- a/docs/comparison_with_webpacker.md
+++ b/docs/comparison_with_webpacker.md
@@ -20,4 +20,4 @@ Here are some considerations between the two:
   `jsbundling-rails` still relies on `sprockets` to output the final `public` assets and create the associated manifest.
   `webpacker`'s complete control over the resulting webpack output files allow it to integrate additional features like automatic [code splitting](https://webpack.js.org/guides/code-splitting/).  Webpack provides advanced optimization to split your statically `import`ed shared dependencies. The `webpacker`/`shakapacker` view helpers will automatically specify each entry point's dependent chunks for you in the resulting HTML.
   With `jsbundling-rails`, you'll be able to manually split out lazy-loaded chunks by using dynamic `import()`s. However, the manual approach would be challenging to maintain on a large project.
-  Why is this important? Code splitting allows the browser to download only the JavasScript and CSS needed for a page, improving performance and SEO.
+  Why is this important? Code splitting allows the browser to download only the JavaScript and CSS needed for a page, improving performance and SEO.


### PR DESCRIPTION
Very minor typo fix `JavasScript` → `JavaScript`