### PR TITLE
Update docs & install for referencing images in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ If you [import CSS](https://esbuild.github.io/content-types/#css-from-js) in you
 Suppose you have an image `app/javascript/images/example.png` that you need to reference in frontend code built with esbuild.
 
 1. Create the image at `app/javascript/images/example.png`.
-1. In `package.json`, under `"scripts"` and `"build"`, add the option `--loader:.png=file` to the esbuild script, which instructs esbuild to copy png files to the build directory.
-1. When esbuild runs, it will copy the png file to something like `app/assets/builds/example-5SRKKTLZ.png`.
+1. In `package.json`, under `"scripts"` and `"build"`, add the additional arguments:
+    * `--loader:.png=file` This instructs esbuild to copy png files to the build directory.
+    * `--asset-names=[name]-[hash].digested` This tells esbuild to append `.digested` to the file name so that sprockets or propshaft will not append an additional digest hash to the file.
+1. When esbuild runs, it will copy the png file to something like `app/assets/builds/example-5SRKKTLZ.digested.png`.
 1. In frontend code, the image is available for import by its original name: `import Example from "../images/example.png"`.
 1. The image itself can now be referenced by its imported name, e.g. in React, `<img src={Example} />`.
-1. The path of the image resolves to `/assets/example-5SRKKTLZ.png`, which is served by the asset pipeline.
+1. The path of the image resolves to `/assets/example-5SRKKTLZ.digested.png`, which is served by the asset pipeline.
 
 ## License
 

--- a/lib/install/esbuild/install.rb
+++ b/lib/install/esbuild/install.rb
@@ -2,7 +2,7 @@ say "Install esbuild"
 run "yarn add esbuild"
 
 say "Add build script"
-build_script = "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets"
+build_script = "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets"
 
 case `npx -v`.to_f
 when 7.1...8.0


### PR DESCRIPTION
This should resolve #76 at least for the **default esbuild** case.
Sprockets has already added support for ignoring `.digested` assets.

As a demonstration I have a reproduction case repo [here](https://github.com/tgaff/jsbundling-rails-image-load).  
* The [main branch](https://github.com/tgaff/jsbundling-rails-image-load/tree/main) shows the problem and [is hosted in production mode here](https://jsbundling-rails-image-load-test.onrender.com/).
* A fixed version exists on the [branch "fix"](https://github.com/tgaff/jsbundling-rails-image-load/tree/fix) and is hosted (and can be seen working) [here](https://jsbundling-rails-image-load-fix.onrender.com/).

_Note the above deploys are "free" render.com instances.  You may need to wait and retry after the initial request while it spins up._

The diff between the two is merely:
```diff
diff --git a/package.json b/package.json
index f740713..7ff9177 100644
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "esbuild": "^0.17.19"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --loader:.png=file"
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --loader:.png=file --asset-names=[name]-[hash].digested"
   }
 }
```

This is mainly a doc change, walking through making this change to the build script.  
However, I think there may be a good argument to be made for just including these in the build script by default.  Not every user will need it but it probably wouldn't do any harm.  (Not sure if we'd want just png, or if we want to include other formats)  Please let me know if you'd like me to prepare that change.