### PR TITLE
Change order of bundler options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaScript Bundling for Rails
 
-Use [Bun](https://bun.sh), [esbuild](https://esbuild.github.io), [rollup.js](https://rollupjs.org), or [Webpack](https://webpack.js.org) to bundle your JavaScript, then deliver it via the asset pipeline in Rails. This gem provides installers to get you going with the bundler of your choice in a new Rails application, and a convention to use `app/assets/builds` to hold your bundled output as artifacts that are not checked into source control (the installer adds this directory to `.gitignore` by default).
+Use [esbuild](https://esbuild.github.io), [rollup.js](https://rollupjs.org), [Webpack](https://webpack.js.org) or [Bun](https://bun.sh) to bundle your JavaScript, then deliver it via the asset pipeline in Rails. This gem provides installers to get you going with the bundler of your choice in a new Rails application, and a convention to use `app/assets/builds` to hold your bundled output as artifacts that are not checked into source control (the installer adds this directory to `.gitignore` by default).
 
 You develop using this approach by running the bundler in watch mode in a terminal with `yarn build --watch` (and your Rails server in another, if you're not using something like [puma-dev](https://github.com/puma/puma-dev)). You can also use `./bin/dev`, which will start both the Rails server and the JS build watcher (along with a CSS build watcher, if you're also using `cssbundling-rails`).
 


### PR DESCRIPTION
While Bun looks very exciting (I'm trying it right now) it just hit v1.0 and it is not yet even possible (or at least clearly documented) how to make it work with stimulus (see https://github.com/excid3/esbuild-rails/issues/23)

For newcomers, having it as the first option could lead them to some issues and configuration pain.

I suggest we keep esbuild as the first option as it is literally plug and play at the moment, stable, documented, and has been around for a while.