### PR TITLE
Add lockb diffing support for Bun

### DIFF
--- a/lib/install/bun/.gitattributes
+++ b/lib/install/bun/.gitattributes
@@ -1,0 +1,2 @@
+# See https://bun.sh/docs/install/lockfile
+*.lockb diff=lockb

--- a/lib/install/bun/install.rb
+++ b/lib/install/bun/install.rb
@@ -18,3 +18,11 @@ package_json = JSON.parse(File.read("package.json"))
 package_json["scripts"] ||= {}
 package_json["scripts"]["build"] = "bun bun.config.js"
 File.write("package.json", JSON.pretty_generate(package_json))
+
+say "Add ability to diff lockb to .gitattributes"
+if Rails.root.join(".gitattributes").exist?
+  append_to_file ".gitattributes", "\n# See https://bun.sh/docs/install/lockfile\n*.lockb diff=lockb\n"
+else
+  copy_file "#{__dir__}/.gitattributes", ".gitattributes"
+end
+say %(Run `git config diff.lockb.textconv bun && git config diff.lockb.binary true` to enable pretty diffs for Bun's .lockb file), :green


### PR DESCRIPTION
Bun ships with a binary lock file called `bun.lockb`. This makes it tricky for merges and gits. To make life easier for Rails devs we should have the defaults for working with this file added to `.gitattributes`. 

Here's an example run

```
☁  test_app [main] ./bin/rails javascript:install:bun
Compile into app/assets/builds
      create  app/assets/builds
      create  app/assets/builds/.keep
      append  app/assets/config/manifest.js
      append  .gitignore
      append  .gitignore
Add JavaScript include tag in application layout
      insert  app/views/layouts/application.html.erb
Create default entrypoint in app/javascript/application.js
      create  app/javascript
      create  app/javascript/application.js
Add default package.json
      create  package.json
Add bin/dev to start foreman
      create  bin/dev
Add default Procfile.dev
      create  Procfile.dev
Ensure foreman is installed
         run  gem install foreman from "."
Successfully installed foreman-0.87.2
Parsing documentation for foreman-0.87.2
Done installing documentation for foreman after 0 seconds
1 gem installed
Add default bun.config.js
      create  bun.config.js
Add build script to package.json
Add ability to diff lockb to .gitattributes
      append  .gitattributes
Run `git config diff.lockb.textconv bun && git config diff.lockb.binary true` to enable pretty diffs for Bun's .lockb file
```

Let's add a really hot JS lib...

```
☁  test_app [main] bun add leftpad
bun add v1.0.0 (822a00c4)

 installed leftpad@0.0.1


 1 packages installed [8.00ms]
 ```
 
And here's the nice diff!

 ```diff
 diff --git a/bun.lockb b/bun.lockb
index da9bea3..45423b2 100755
--- a/bun.lockb
+++ b/bun.lockb
@@ -1,6 +1,6 @@
 # THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
 # yarn lockfile v1
-# bun ./bun.lockb --hash: 5DA53CFB274FB1D4-9feadbd5bf3ab070-B09F5E779FD1315D-576d909a8d0e014d
+# bun ./bun.lockb --hash: 9F93D6F459FB2907-99c8645f3c9c6703-37EDD41CC550C45A-5bfaf1dee528bde5


 "@nodelib/fs.scandir@2.1.5":
@@ -87,6 +87,11 @@ is-number@^7.0.0:
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==

+leftpad@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/leftpad/-/leftpad-0.0.1.tgz"
+  integrity sha512-kBAuxBQJlJ85LDc+SnGSX6gWJnJR9Qk4lbgXmz/qPfCOCieCk7BgoN3YvzoNr5BUjqxQDOQxawJJvXXd6c+6Mg==
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
diff --git a/package.json b/package.json
index fead08c..b0576be 100644
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "bun bun.config.js"
   },
   "dependencies": {
-    "esbuild-rails": "^1.0.7"
+    "esbuild-rails": "^1.0.7",
+    "leftpad": "^0.0.1"
   }
 }
 ```