### PR TITLE
Allow NPM use for install/build

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -24,13 +24,15 @@ module Jsbundling
 
     def install_command
       return "bun install" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
-      return "yarn install" if File.exist?('yarn.lock') || tool_exists?('yarn')
+      return "yarn install" if File.exist?('yarn.lock') || (tool_exists?('yarn') && !File.exist?('package-lock.json'))
+      return "npm install" if File.exist?('package-lock.json') || tool_exists?('npm')
       raise "jsbundling-rails: No suitable tool found for installing JavaScript dependencies"
     end
 
     def build_command
       return "bun run build" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
-      return "yarn build" if File.exist?('yarn.lock') || tool_exists?('yarn')
+      return "yarn build" if File.exist?('yarn.lock') || (tool_exists?('yarn') && !File.exist?('package-lock.json'))
+      return "npm run build" if File.exist?('package-lock.json') || tool_exists?('npm')
       raise "jsbundling-rails: No suitable tool found for building JavaScript"
     end
 


### PR DESCRIPTION
Fixes partly #176.

At my company, we're moving away from yarn as it does not bring a lot of value in our use cases and we'd rather stick with the defaults, but this gem assumes/requires yarn.

This PR falls back on `npm` for installing packages + running the build script in bun/yarn is not present.

This PR does not (yet) add `npm` support for the generators (Procfile.dev, etc) however; should I add it here and take inspiration from the [Bun PR](https://github.com/rails/jsbundling-rails/pull/167/files#diff-c8be7735fb1a6f72dfe60eaf3817534ffb2a69baf7dc2532ec7ad0655d075c23) ?