### PR TITLE
Set `"private": true` in package.json

### DIFF
--- a/lib/install/package.json
+++ b/lib/install/package.json
@@ -1,4 +1,4 @@
 {
   "name": "app",
-  "private": "true"
+  "private": true
 }


### PR DESCRIPTION
## Problem

The `package.json` file sets `"private": "true"`, when this value [is meant to be a boolean](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#private).

This is causing a slight problem for me when running [`syft`](https://github.com/anchore/syft) (a tool to generate an [SBOM](https://en.wikipedia.org/wiki/Software_supply_chain)) against a Docker image containing `jsbundling-rails`:

```
[0000]  INFO syft version: 0.99.0
[0017]  INFO identified distro: Rocky Linux 8.4 (Green Obsidian)
[0017]  INFO cataloging an image
[0019]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: json: cannot unmarshal string into Go struct field packageJSON.private of type bool location=/home/code/vendor/bundle/ruby/3.1.0/gems/jsbundling-rails-1.2.1/lib/install/package.json
[0019]  WARN unable to extract licenses from javascript package.json: unmarshal failed
```

This means that `syft` is unable to count `jsbundling-rails` among the list of dependencies in my project, which makes the SBOM slightly inaccurate. This is not a high-priority issue, but also the problem is not solely cosmetic.

## Fix

Update `package.json` to use `"private": true`.