### PR TITLE
Support using `SKIP_JS_INSTALL` env variable as an alias for `SKIP_YARN_INSTALL`/`SKIP_BUN_INSTALL`

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -15,7 +15,7 @@ namespace :javascript do
     end
   end
 
-  build_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
+  build_task.prereqs << :install unless ENV["SKIP_JS_INSTALL"] || ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
 end
 
 module Jsbundling


### PR DESCRIPTION
Support for NPM/PNPM was recently merged, but the name of the environment variable used to skip dependencies installation still refers to Yarn or Bun.
This PR introduces a new unified name for the environment variable: `SKIP_JS_INSTALL` (which aims to be consistent with `SKIP_JS_BUILD` introduced in #144), to avoid referring to a specific package manager.
`SKIP_YARN_INSTALL` and `SKIP_BUN_INSTALL` are obviously still there for backwards compatibility.