### PR TITLE
Use `overmind` to run Procfiles, if available

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -1,11 +1,16 @@
 #!/usr/bin/env sh
 
-if gem list --no-installed --exact --silent foreman; then
-  echo "Installing foreman..."
-  gem install foreman
+# Default to port 3001 if not specified
+export PORT="${PORT:-3001}"
+
+if command -v overmind >/dev/null 2>&1; then
+  task_runner="overmind"
+else
+  if ! gem list --no-installed --exact --silent foreman; then
+    echo "Installing foreman..."
+    gem install foreman
+  fi
+  task_runner="foreman"
 fi
 
-# Default to port 3000 if not specified
-export PORT="${PORT:-3000}"
-
-exec foreman start -f Procfile.dev "$@"
+exec $task_runner start -f Procfile.dev "$@"


### PR DESCRIPTION
[Overmind] is a process manager (like foreman) for Procfile-based applications. The advantage is that it [allows to use debuggers] like pry or `binding.irb` without installing extra gems.

---

This PR is very simple, as I'm waiting for feedback on whether the maintainers like this idea. I can add tests and a CHANGELOG entry after that. I'll also open a PR on cssbundling-rails if this one is accepted.

[Overmind]: https://github.com/DarthSim/overmind
[allows to use debuggers]: https://heyvaleria.github.io/coding/2022/04/27/overmind.html