### PR TITLE
Replace `command` with `which` in tool_exists

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -43,7 +43,7 @@ module Jsbundling
     end
 
     def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null"
+      system "which #{tool} > /dev/null"
     end
 
     def tool


### PR DESCRIPTION
`command` is a built-in shell command in linux (at least in debian , ubuntu and similars)
If executed in ruby system it return *nil* (inspecting: *127 command not found*)
This not happens with `which`, that is a system command.
  
I 've done a PR for fast, but if you prefer I can open a simple issue. 🙂
TY