### PR TITLE
Include .gitattributes when building the gem

### DIFF
--- a/jsbundling-rails.gemspec
+++ b/jsbundling-rails.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |spec|
   spec.summary     = "Bundle and transpile JavaScript in Rails with bun, esbuild, rollup.js, or Webpack."
   spec.license     = "MIT"
 
-  spec.files = Dir["lib/**/*", "MIT-LICENSE", "README.md"]
+  spec.files = Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+  spec.files += ["LICENSE", "README.md"]
 
   spec.add_dependency "railties", ">= 6.0.0"
 end


### PR DESCRIPTION
`lib/install/bun/.gitattributes` was missing from the final build of the gem. This was causing an error during installation when `jsbundling-rails` tried to copy its own `.gitattributes` into host project's root.

`Dir["lib/**/*"]` does not include files starting with a dot, so I replaced it with a method that does include them. Also stripped directories from the list because according to the [specification](https://guides.rubygems.org/specification-reference/#files), they are ignored anyway:

> Only add files you can require to this list, not directories, etc.
> Directories are automatically stripped from this list when building a gem, other non-files cause an error.

Fixes https://github.com/rails/jsbundling-rails/issues/175


Proof:


```ruby
Dir.glob("lib/**/*", File::FNM_DOTMATCH).any? { |path| path.include?(".gitattributes") }
=> true
```

vs

```ruby
Dir["lib/**/*"].any? { |path| path.include?(".gitattributes") }
=> false
```