### PR TITLE
chore: Move esbuild|rollup|webpack to devDependencies instead of dependencies

### DIFF
--- a/lib/install/esbuild/install.rb
+++ b/lib/install/esbuild/install.rb
@@ -2,7 +2,7 @@ apply "#{__dir__}/../install.rb"
 apply "#{__dir__}/../install_procfile.rb"
 
 say "Install esbuild"
-run "yarn add esbuild"
+run "yarn add --dev esbuild"
 
 say "Add build script"
 build_script = "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"

--- a/lib/install/rollup/install.rb
+++ b/lib/install/rollup/install.rb
@@ -3,7 +3,7 @@ apply "#{__dir__}/../install_procfile.rb"
 
 say "Install rollup with config"
 copy_file "#{__dir__}/rollup.config.js", "rollup.config.js"
-run "yarn add rollup @rollup/plugin-node-resolve"
+run "yarn add --dev rollup @rollup/plugin-node-resolve"
 
 say "Add build script"
 build_script = "rollup -c --bundleConfigAsCjs rollup.config.js"

--- a/lib/install/webpack/install.rb
+++ b/lib/install/webpack/install.rb
@@ -3,7 +3,7 @@ apply "#{__dir__}/../install_procfile.rb"
 
 say "Install Webpack with config"
 copy_file "#{__dir__}/webpack.config.js", "webpack.config.js"
-run "yarn add webpack webpack-cli"
+run "yarn add --dev webpack webpack-cli"
 
 say "Add build script"
 build_script = "webpack --config webpack.config.js"


### PR DESCRIPTION
In the JavaScript community, build tools are usually installed in devDependencies, so add the `--dev` option:

```
yarn add --dev esbuild
```

For example:
https://esbuild.github.io/getting-started/

```
npm install --save-exact --save-dev esbuild
```
