### PR TITLE
Allow for overriding `build_command`

### DIFF
--- a/lib/jsbundling/tasks.rb
+++ b/lib/jsbundling/tasks.rb
@@ -1,0 +1,42 @@
+module Jsbundling
+  module Tasks
+    extend self
+
+    def install_command
+      case tool
+      when :bun then "bun install"
+      when :yarn then "yarn install"
+      when :pnpm then "pnpm install"
+      when :npm then "npm install"
+      else raise "jsbundling-rails: No suitable tool found for installing JavaScript dependencies"
+      end
+    end
+
+    def build_command
+      case tool
+      when :bun then "bun run build"
+      when :yarn then "yarn build"
+      when :pnpm then "pnpm build"
+      when :npm then "npm run build"
+      else raise "jsbundling-rails: No suitable tool found for building JavaScript"
+      end
+    end
+
+    def tool_exists?(tool)
+      system "command -v #{tool} > /dev/null"
+    end
+
+    def tool
+      case
+      when File.exist?('bun.lockb') then :bun
+      when File.exist?('yarn.lock') then :yarn
+      when File.exist?('pnpm-lock.yaml') then :pnpm
+      when File.exist?('package-lock.json') then :npm
+      when tool_exists?('bun') then :bun
+      when tool_exists?('yarn') then :yarn
+      when tool_exists?('pnpm') then :pnpm
+      when tool_exists?('npm') then :npm
+      end
+    end
+  end
+end

--- a/lib/jsbundling/tasks.rb
+++ b/lib/jsbundling/tasks.rb
@@ -2,6 +2,8 @@ module Jsbundling
   module Tasks
     extend self
 
+    attr_writer :build_command
+
     def install_command
       case tool
       when :bun then "bun install"
@@ -13,6 +15,10 @@ module Jsbundling
     end
 
     def build_command
+      if @build_command
+        return @build_command
+      end
+
       case tool
       when :bun then "bun run build"
       when :yarn then "yarn build"

--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,3 +1,5 @@
+require "jsbundling/tasks"
+
 namespace :javascript do
   desc "Install JavaScript dependencies"
   task :install do
@@ -16,49 +18,6 @@ namespace :javascript do
   end
 
   build_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
-end
-
-module Jsbundling
-  module Tasks
-    extend self
-
-    def install_command
-      case tool
-      when :bun then "bun install"
-      when :yarn then "yarn install"
-      when :pnpm then "pnpm install"
-      when :npm then "npm install"
-      else raise "jsbundling-rails: No suitable tool found for installing JavaScript dependencies"
-      end
-    end
-
-    def build_command
-      case tool
-      when :bun then "bun run build"
-      when :yarn then "yarn build"
-      when :pnpm then "pnpm build"
-      when :npm then "npm run build"
-      else raise "jsbundling-rails: No suitable tool found for building JavaScript"
-      end
-    end
-
-    def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null"
-    end
-
-    def tool
-      case
-      when File.exist?('bun.lockb') then :bun
-      when File.exist?('yarn.lock') then :yarn
-      when File.exist?('pnpm-lock.yaml') then :pnpm
-      when File.exist?('package-lock.json') then :npm
-      when tool_exists?('bun') then :bun
-      when tool_exists?('yarn') then :yarn
-      when tool_exists?('pnpm') then :pnpm
-      when tool_exists?('npm') then :npm
-      end
-    end
-  end
 end
 
 unless ENV["SKIP_JS_BUILD"]

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "jsbundling/tasks"
+
+class TasksTest < ActiveSupport::TestCase
+  test "override build_command" do
+    original_build_command = Jsbundling::Tasks.build_command
+    Jsbundling::Tasks.build_command = "hello there"
+    assert_equal("hello there", Jsbundling::Tasks.build_command)
+
+    Jsbundling::Tasks.build_command = nil
+    assert_equal(original_build_command, Jsbundling::Tasks.build_command)
+  ensure
+    Jsbundling::Tasks.build_command = nil
+  end
+end


### PR DESCRIPTION
Hello!

I'd like to rename my `yarn build` to `yarn build:js` because the `build` script is used by my deployment system. This PR makes this possible. I tried to keep the code change pretty small, but I moved the Tasks module into its own file so that I could write tests for it.

I considered allowing the install command to also be overridden, but I didn't think that would be too useful since it should only really get run once per application.

If this gets merged, I'm planning on updating my app's Rakefile to the following:

```ruby
require_relative "config/application"

Rails.application.load_tasks

Jsbundling::Tasks.build_command = "yarn build:js"
```