### PR TITLE
Remove --public-path from build_script

### DIFF
--- a/lib/install/esbuild/install.rb
+++ b/lib/install/esbuild/install.rb
@@ -5,7 +5,7 @@ say "Install esbuild"
 run "yarn add --dev esbuild"
 
 say "Add build script"
-build_script = "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"
+build_script = "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds"
 
 case `npx -v`.to_f
 when 7.1...8.0


### PR DESCRIPTION
This PR removes the '--public-path=/assets` option from the generator (install.rb).

Background: The esbuild option `--public-path` is meant to be used to define alternate absolute asset hosts for file loaders. The documentation under https://esbuild.github.io/api/#public-path gives an example of `--public-path=https://www.example.com/v1`.

Using it to prefix `/assets` is incorrect usage I believe and unnecessary.

When esbuild encounters a `url(...)` it will add the prefix to the rewritten url, but it will not impact the file location where the asset is stored by esbuild.

Setting `--public-path=/assets` will thus interfere with downstream asset processing (for example Sprocket's AssetUrlProcessor), because the corresponding asset can't be found on disk. The asset processor is looking to resolve the prefixed URL, but can't find it because `esbuild` isn't adding the public path to files written to `outdir`.

I believe this went unnoticed, because using this option only affects `--loader:xxx=file` (for instance when handling `ttf` or `woff2`) and when using `esbuild` to handle such assets at all (for instance when importing CSS via yarn).

Since asset urls are rewritten anyway, removing --public-path doesn't have a negative impact.