### PR TITLE
Support Bun 1.2 that throws Error on Build

### DIFF
--- a/lib/install/bun/bun.config.js
+++ b/lib/install/bun/bun.config.js
@@ -5,20 +5,16 @@ const config = {
   sourcemap: "external",
   entrypoints: ["app/javascript/application.js"],
   outdir: path.join(process.cwd(), "app/assets/builds"),
+  throw: !process.argv.includes('--watch'),
 };
 
 const build = async (config) => {
   const result = await Bun.build(config);
 
   if (!result.success) {
-    if (process.argv.includes('--watch')) {
-      console.error("Build failed");
-      for (const message of result.logs) {
-        console.error(message);
-      }
-      return;
-    } else {
-      throw new AggregateError(result.logs, "Build failed");
+    console.error("Build failed");
+    for (const message of result.logs) {
+      console.error(message);
     }
   }
 };


### PR DESCRIPTION
We need to suppress the error or the command fails despite the `--watch` command. 

The default behavior changed https://github.com/oven-sh/bun/pull/15861