### PR TITLE
Detect Bun tool when using bun.lock and yarn.lock

### DIFF
--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -49,6 +49,7 @@ module Jsbundling
     def tool
       case
       when File.exist?('bun.lockb') then :bun
+      when File.exist?('bun.lock') then :bun
       when File.exist?('yarn.lock') then :yarn
       when File.exist?('pnpm-lock.yaml') then :pnpm
       when File.exist?('package-lock.json') then :npm

--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -42,21 +42,23 @@ module Jsbundling
       end
     end
 
-    def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null"
+    def tool
+      tool_determined_by_config_file || tool_determined_by_executable
     end
 
-    def tool
+    def tool_determined_by_config_file
       case
-      when File.exist?("bun.lockb") then :bun
-      when File.exist?("bun.lock") then :bun
-      when File.exist?("yarn.lock") then :yarn
-      when File.exist?("pnpm-lock.yaml") then :pnpm
+      when File.exist?("bun.lockb")         then :bun
+      when File.exist?("bun.lock")          then :bun
+      when File.exist?("yarn.lock")         then :yarn
+      when File.exist?("pnpm-lock.yaml")    then :pnpm
       when File.exist?("package-lock.json") then :npm
-      when tool_exists?("bun") then :bun
-      when tool_exists?("yarn") then :yarn
-      when tool_exists?("pnpm") then :pnpm
-      when tool_exists?("npm") then :npm
+      end
+    end
+
+    def tool_determined_by_executable
+      %i[ bun yarn pnpm npm ].each do |exe|
+        return exe if system "command -v #{exe} > /dev/null"
       end
     end
   end

--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -48,15 +48,15 @@ module Jsbundling
 
     def tool
       case
-      when File.exist?('bun.lockb') then :bun
-      when File.exist?('bun.lock') then :bun
-      when File.exist?('yarn.lock') then :yarn
-      when File.exist?('pnpm-lock.yaml') then :pnpm
-      when File.exist?('package-lock.json') then :npm
-      when tool_exists?('bun') then :bun
-      when tool_exists?('yarn') then :yarn
-      when tool_exists?('pnpm') then :pnpm
-      when tool_exists?('npm') then :npm
+      when File.exist?("bun.lockb") then :bun
+      when File.exist?("bun.lock") then :bun
+      when File.exist?("yarn.lock") then :yarn
+      when File.exist?("pnpm-lock.yaml") then :pnpm
+      when File.exist?("package-lock.json") then :npm
+      when tool_exists?("bun") then :bun
+      when tool_exists?("yarn") then :yarn
+      when tool_exists?("pnpm") then :pnpm
+      when tool_exists?("npm") then :npm
       end
     end
   end


### PR DESCRIPTION
## Summary
Resolves https://github.com/rails/jsbundling-rails/issues/212

The build task incorrectly detect `yarn` as the JS tool when using Bun's text-based lockfile (`bun.lock`) if a `yarn.lock` is also present. The text-based lockfile was introduced in Bun `v1.1.39`.

## Why would `bun.lock` and `yarn.lock` both exist?

Bun [supports](https://bun.sh/docs/install/lockfile) generating a `yarn.lock` file _in addition_ to its own lockfile. Producing the `yarn.lock` file can be useful for integrating with tools that only know (how) to parse `yarn.lock` files, such as dependency report generators.

## The fix

This checks for `bun.lock` ahead of `yarn.lock` to ensure Bun is detected as the tool.

### Add additional control?
The is adjacent to https://github.com/rails/cssbundling-rails/issues/169.

Perhaps a config that allows setting & _differentiating_ the package manager and bundler would be reasonable. On the other hand, it should already be possible to achieve that by monkey-patching `Jsbundling::Tasks`.