### PR TITLE
Detect package manager in install tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             gemfile: gemfiles/rails_8_0.gemfile
           - ruby-version: "3.1"
             gemfile: gemfiles/rails_main.gemfile
+          - ruby-version: "3.2"
+            gemfile: gemfiles/rails_main.gemfile
 
     name: ${{ format('Tests (Ruby {0}, {1})', matrix.ruby-version, matrix.gemfile) }}
     runs-on: ubuntu-latest

--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
-js: yarn build --watch
+js: #{npm_build_watch}

--- a/lib/install/esbuild/install.rb
+++ b/lib/install/esbuild/install.rb
@@ -2,7 +2,7 @@ apply "#{__dir__}/../install.rb"
 apply "#{__dir__}/../install_procfile.rb"
 
 say "Install esbuild"
-run "yarn add --dev esbuild"
+run Jsbundling::PackageManager.add_command("esbuild", dev: true)
 
 say "Add build script"
 build_script = "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"
@@ -10,10 +10,10 @@ build_script = "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --o
 case `npx -v`.to_f
 when 7.1...8.0
   run %(npm set-script build "#{build_script}")
-  run %(yarn build)
+  run Jsbundling::PackageManager.build_command
 when (8.0..)
   run %(npm pkg set scripts.build="#{build_script}")
-  run %(yarn build)
+  run Jsbundling::PackageManager.build_command
 else
   say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green
 end

--- a/lib/install/install_procfile.rb
+++ b/lib/install/install_procfile.rb
@@ -1,8 +1,9 @@
 if Rails.root.join("Procfile.dev").exist?
-  append_to_file "Procfile.dev", "js: yarn build --watch\n"
+  append_to_file "Procfile.dev", "js: #{Jsbundling::PackageManager.build_command(with_watch:true)}\n"
 else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"
+  gsub_file "Procfile.dev", 'js: #{npm_build_watch}', "js: #{Jsbundling::PackageManager.build_command(with_watch:true)}"
 
   say "Ensure foreman is installed"
   run "gem install foreman"

--- a/lib/install/rollup/install.rb
+++ b/lib/install/rollup/install.rb
@@ -3,7 +3,7 @@ apply "#{__dir__}/../install_procfile.rb"
 
 say "Install rollup with config"
 copy_file "#{__dir__}/rollup.config.js", "rollup.config.js"
-run "yarn add --dev rollup @rollup/plugin-node-resolve"
+run Jsbundling::PackageManager.add_command("rollup @rollup/plugin-node-resolve", dev: true)
 
 say "Add build script"
 build_script = "rollup -c --bundleConfigAsCjs rollup.config.js"
@@ -11,10 +11,10 @@ build_script = "rollup -c --bundleConfigAsCjs rollup.config.js"
 case `npx -v`.to_f
 when 7.1...8.0
   run %(npm set-script build "#{build_script}")
-  run %(yarn build)
+  run Jsbundling::PackageManager.build_command
 when (8.0..)
   run %(npm pkg set scripts.build="#{build_script}")
-  run %(yarn build)
+  run Jsbundling::PackageManager.build_command
 else
   say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green
 end

--- a/lib/install/webpack/install.rb
+++ b/lib/install/webpack/install.rb
@@ -3,7 +3,7 @@ apply "#{__dir__}/../install_procfile.rb"
 
 say "Install Webpack with config"
 copy_file "#{__dir__}/webpack.config.js", "webpack.config.js"
-run "yarn add --dev webpack webpack-cli"
+run Jsbundling::PackageManager.add_command("webpack webpack-cli", dev: true)
 
 say "Add build script"
 build_script = "webpack --config webpack.config.js"
@@ -11,10 +11,10 @@ build_script = "webpack --config webpack.config.js"
 case `npx -v`.to_f
 when 7.1...8.0
   run %(npm set-script build "#{build_script}")
-  run %(yarn build)
+  run Jsbundling::PackageManager.build_command
 when (8.0..)
   run %(npm pkg set scripts.build="#{build_script}")
-  run %(yarn build)
+  run Jsbundling::PackageManager.build_command
 else
   say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green
 end

--- a/lib/jsbundling/package_manager.rb
+++ b/lib/jsbundling/package_manager.rb
@@ -1,0 +1,90 @@
+require "pathname"
+
+module Jsbundling
+  module PackageManager
+    extend self
+
+    MANAGERS = {
+      bun: {
+        add: "bun add %s",
+        add_dev: "bun add %s --dev",
+        install: "bun install",
+        build: "bun run build"
+      },
+      pnpm: {
+        add: "pnpm add %s",
+        add_dev: "pnpm add -D %s",
+        install: "pnpm install",
+        build: "pnpm run build"
+      },
+      npm: {
+        add: "npm install %s",
+        add_dev: "npm install -D %s",
+        install: "npm ci",
+        build: "npm run build"
+      },
+      yarn: {
+        add: "yarn add %s",
+        add_dev: "yarn add --dev %s",
+        install: "yarn install",
+        build: "yarn build"
+      }
+    }.freeze
+
+    def self.detect(root)
+      if root.join("bun.lock").exist? || root.join("bun.lockb").exist? || root.join("bun.config.js").exist?
+        :bun
+      elsif root.join("pnpm-lock.yaml").exist?
+        :pnpm
+      elsif root.join("package-lock.json").exist?
+        :npm
+      else
+        detect_by_executable || :yarn
+      end
+    end
+
+    def detect_by_executable
+      %i[ bun yarn pnpm npm ].each do |exe|
+        return exe if system "command -v #{exe} > /dev/null"
+      end
+
+      nil
+    end
+
+    def package_manager
+      @package_manager ||= PackageManager.detect(project_root)
+    end
+
+    def add_command(package, dev: false)
+      if dev
+        MANAGERS.dig(package_manager, :add_dev) % package
+      else
+        MANAGERS.dig(package_manager, :add) % package
+      end
+    end
+
+    def install_command
+      MANAGERS.dig(package_manager, :install)
+    end
+
+    def build_command(with_watch: false)
+      package_build_command = MANAGERS.dig(package_manager, :build)
+
+      if with_watch
+        if package_manager == :npm || package_manager == :pnpm
+          package_build_command += " -- --watch"
+        else
+          package_build_command += " --watch"
+        end
+      end
+
+      package_build_command
+    end
+
+    private
+
+    def project_root
+      Pathname(!Rails.root.nil? ? Rails.root : Dir.pwd)
+    end
+  end
+end

--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -1,67 +1,21 @@
+require "jsbundling/package_manager"
+
 namespace :javascript do
   desc "Install JavaScript dependencies"
   task :install do
-    command = Jsbundling::Tasks.install_command
-    unless system(command)
-      raise "jsbundling-rails: Command install failed, ensure #{command.split.first} is installed"
+    unless system(Jsbundling::PackageManager.install_command)
+      raise "jsbundling-rails: Command install failed, ensure #{Jsbundling::PackageManager.package_manager} is installed"
     end
   end
 
   desc "Build your JavaScript bundle"
   build_task = task :build do
-    command = Jsbundling::Tasks.build_command
-    unless system(command)
-      raise "jsbundling-rails: Command build failed, ensure `#{command}` runs without errors"
+    unless system(Jsbundling::PackageManager.build_command)
+      raise "jsbundling-rails: Command build failed, ensure `#{Jsbundling::PackageManager.build_command}` runs without errors"
     end
   end
 
   build_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
-end
-
-module Jsbundling
-  module Tasks
-    extend self
-
-    def install_command
-      case tool
-      when :bun then "bun install"
-      when :yarn then "yarn install"
-      when :pnpm then "pnpm install"
-      when :npm then "npm install"
-      else raise "jsbundling-rails: No suitable tool found for installing JavaScript dependencies"
-      end
-    end
-
-    def build_command
-      case tool
-      when :bun then "bun run build"
-      when :yarn then "yarn build"
-      when :pnpm then "pnpm build"
-      when :npm then "npm run build"
-      else raise "jsbundling-rails: No suitable tool found for building JavaScript"
-      end
-    end
-
-    def tool
-      tool_determined_by_config_file || tool_determined_by_executable
-    end
-
-    def tool_determined_by_config_file
-      case
-      when File.exist?("bun.lockb")         then :bun
-      when File.exist?("bun.lock")          then :bun
-      when File.exist?("yarn.lock")         then :yarn
-      when File.exist?("pnpm-lock.yaml")    then :pnpm
-      when File.exist?("package-lock.json") then :npm
-      end
-    end
-
-    def tool_determined_by_executable
-      %i[ bun yarn pnpm npm ].each do |exe|
-        return exe if system "command -v #{exe} > /dev/null"
-      end
-    end
-  end
 end
 
 unless ENV["SKIP_JS_BUILD"]

--- a/test/esbuild_installer_test.rb
+++ b/test/esbuild_installer_test.rb
@@ -5,7 +5,7 @@ class EsbuildInstallerTest < ActiveSupport::TestCase
   include RailsAppHelpers
   include SharedInstallerTests
 
-  test "esbuild installer" do
+  test "esbuild installer with yarn by default" do
     with_new_rails_app do
       out, _err = run_installer
 
@@ -20,9 +20,63 @@ class EsbuildInstallerTest < ActiveSupport::TestCase
     end
   end
 
+  test "esbuild installer with yarn.lock exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("yarn.lock", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: yarn build --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+      assert_match %r{STUBBED yarn add.* esbuild}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)esbuild app/javascript/\*\.\*}, out
+      assert_match "STUBBED yarn build", out
+    end
+  end
+
+  test "esbuild installer with npm when package-lock.json exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("package-lock.json", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: npm run build -- --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+      assert_match %r{STUBBED npm install.* esbuild}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)esbuild app/javascript/\*\.\*}, out
+      assert_match "STUBBED npm run build", out
+    end
+  end
+
+  test "esbuild installer with pnpm when pnpm-lock.yaml exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("pnpm-lock.yaml", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: pnpm run build -- --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+      assert_match %r{STUBBED pnpm add.* esbuild}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)esbuild app/javascript/\*\.\*}, out
+      assert_match "STUBBED pnpm run build", out
+    end
+  end
+
   private
     def run_installer
-      stub_bins("gem", "yarn", "npm")
+      stub_bins("gem", "yarn", "npm", "pnpm")
       run_command("bin/rails", "javascript:install:esbuild")
     end
 end

--- a/test/rollup_installer_test.rb
+++ b/test/rollup_installer_test.rb
@@ -5,7 +5,7 @@ class RollupInstallerTest < ActiveSupport::TestCase
   include RailsAppHelpers
   include SharedInstallerTests
 
-  test "rollup installer" do
+  test "rollup installer with yarn by default" do
     with_new_rails_app do
       out, _err = run_installer
 
@@ -23,9 +23,72 @@ class RollupInstallerTest < ActiveSupport::TestCase
     end
   end
 
+  test "rollup installer with yarn when yarn.lock exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("yarn.lock", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: yarn build --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+
+      assert File.exist?("rollup.config.js")
+
+      assert_match %r{STUBBED yarn add.* rollup}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)rollup .*rollup.config.js}, out
+      assert_match "STUBBED yarn build", out
+    end
+  end
+
+  test "rollup installer with npm when package-lock.json exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("package-lock.json", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: npm run build -- --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+
+      assert File.exist?("rollup.config.js")
+
+      assert_match %r{STUBBED npm install.* rollup}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)rollup .*rollup.config.js}, out
+      assert_match "STUBBED npm run build", out
+    end
+  end
+
+  test "rollup installer with pnpm when pnpm-lock.yaml exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("pnpm-lock.yaml", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: pnpm run build -- --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+
+      assert File.exist?("rollup.config.js")
+
+      assert_match %r{STUBBED pnpm add.* rollup}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)rollup .*rollup.config.js}, out
+      assert_match "STUBBED pnpm run build", out
+    end
+  end
+
   private
     def run_installer
-      stub_bins("gem", "yarn", "npm")
+      stub_bins("gem", "yarn", "npm", "pnpm")
       run_command("bin/rails", "javascript:install:rollup")
     end
 end

--- a/test/webpack_installer_test.rb
+++ b/test/webpack_installer_test.rb
@@ -5,7 +5,7 @@ class WebpackInstallerTest < ActiveSupport::TestCase
   include RailsAppHelpers
   include SharedInstallerTests
 
-  test "webpack installer" do
+  test "webpack installer with yarn by default" do
     with_new_rails_app do
       out, _err = run_installer
 
@@ -23,9 +23,72 @@ class WebpackInstallerTest < ActiveSupport::TestCase
     end
   end
 
+  test "webpack installer with yarn when yarn.lock exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("yarn.lock", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: yarn build --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+
+      assert File.exist?("webpack.config.js")
+
+      assert_match %r{STUBBED yarn add.* webpack}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)webpack --config webpack.config.js}, out
+      assert_match "STUBBED yarn build", out
+    end
+  end
+
+  test "webpack installer with npm when package-lock.json exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("package-lock.json", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: npm run build -- --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+
+      assert File.exist?("webpack.config.js")
+
+      assert_match %r{STUBBED npm install.* webpack}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)webpack --config webpack.config.js}, out
+      assert_match "STUBBED npm run build", out
+    end
+  end
+
+  test "webpack installer with pnpm when pnpm-lock.yaml exists" do
+    with_new_rails_app do
+      File.write("package.json", "\n", mode: "a+")
+      File.write("pnpm-lock.yaml", "\n", mode: "a+")
+
+      out, _err = run_installer
+
+      File.read("Procfile.dev").tap do |procfile|
+        assert_match "js: pnpm run build -- --watch", procfile
+      end
+
+      assert_match "STUBBED gem install foreman", out
+
+      assert File.exist?("webpack.config.js")
+
+      assert_match %r{STUBBED pnpm add.* webpack}, out
+      assert_match %r{STUBBED npm (?:set-script build |pkg set scripts.build=)webpack --config webpack.config.js}, out
+      assert_match "STUBBED pnpm run build", out
+    end
+  end
+
   private
     def run_installer
-      stub_bins("gem", "yarn", "npm")
+      stub_bins("gem", "yarn", "npm", "pnpm")
       run_command("bin/rails", "javascript:install:webpack")
     end
 end


### PR DESCRIPTION
### Motivation / Background
In the build tasks (`build.rake`), the package manager is detected dynamically and the corresponding build command is executed.
However, in the install tasks (`install.rake`), the `yarn` command is hardcoded.
As a result, when installing the jsbundling-rails gem and running `./bin/rails javascript:install:[bun|esbuild|rollup|webpack]`, the setup is always configured to use Yarn.
- https://github.com/rails/jsbundling-rails/blob/7d5afa913bfe1c3d8f4f630ff604660d425ac830/lib/install/webpack/install.rb#L6
- https://github.com/rails/jsbundling-rails/blob/7d5afa913bfe1c3d8f4f630ff604660d425ac830/lib/install/esbuild/install.rb#L5

- Related Issue: #217

### Detail
This Pull Request adds package manager detection to the install tasks.

To detect the package manager, this PR introduces `Jsbundling::PackageManager`, following the same approach used in rails/rails:
- https://github.com/rails/rails/pull/56636

`Jsbundling::PackageManager` replaces the inline `Jsbundling::Tasks` implementation currently embedded in `build.rake`.
https://github.com/rails/jsbundling-rails/blob/7d5afa913bfe1c3d8f4f630ff604660d425ac830/lib/tasks/jsbundling/build.rake#L21-L22

The detection logic is aligned with `Rails::Generators::JsPackageManager` and shared between the install tasks and build tasks.

This helps keep jsbundling-rails behavior consistent with Rails core generators.

### Additional information
#### Default package manager
If no lockfile such as `bun.lockb` or `package-lock.json` is found, Yarn is used as the default package manager.
This behavior is aligned with the current released Rails version (v8.1.2).
In addition, as in the current jsbundling-rails implementation, this PR also checks for available executable package managers.

If the `--package-manager` option for `rails new` (proposed in the following PR) is merged, I plan to add a corresponding option to jsbundling-rails as well.
- https://github.com/rails/rails/pull/56637

#### CI: Drop support for Ruby 3.2 for rails-main (rails 8.2)
The rails/rails main branch has dropped support for Ruby 3.2, so Ruby 3.2 has been removed from the rails-dev CI matrix.