### PR TITLE
Add `javascript:watch` task and Puma Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Use [Bun](https://bun.sh), [esbuild](https://esbuild.github.io), [rollup.js](https://rollupjs.org), or [Webpack](https://webpack.js.org) to bundle your JavaScript, then deliver it via the asset pipeline in Rails. This gem provides installers to get you going with the bundler of your choice in a new Rails application, and a convention to use `app/assets/builds` to hold your bundled output as artifacts that are not checked into source control (the installer adds this directory to `.gitignore` by default).
 
-You develop using this approach by running the bundler in watch mode in a terminal with `yarn build --watch` (and your Rails server in another, if you're not using something like [puma-dev](https://github.com/puma/puma-dev)). You can also use `./bin/dev`, which will start both the Rails server and the JS build watcher (along with a CSS build watcher, if you're also using `cssbundling-rails`).
+You develop using this approach by running the bundler in watch mode in a terminal with `bin/rails javascript:watch` (and your Rails server in another, if you're not using something like [puma-dev](https://github.com/puma/puma-dev)). You can also use `./bin/dev`, which will start both the Rails server and the JS build watcher (along with a CSS build watcher, if you're also using `cssbundling-rails`).
 
 Whenever the bundler detects changes to any of the JavaScript files in your project, it'll bundle `app/javascript/application.js` into `app/assets/builds/application.js` (and all other entry points configured). You can refer to the build output in your layout using the standard asset pipeline approach with `<%= javascript_include_tag "application", defer: true %>`.
 
@@ -59,6 +59,16 @@ Suppose you have an image `app/javascript/images/example.png` that you need to r
 1. In frontend code, the image is available for import by its original name: `import Example from "../images/example.png"`.
 1. The image itself can now be referenced by its imported name, e.g. in React, `<img src={Example} />`.
 1. The path of the image resolves to `/assets/example-5SRKKTLZ.digested.png`, which is served by the asset pipeline.
+
+### Does jsbundling-rails require bin/dev?
+
+This gem ships with a Puma plugin. To use it, add this line to your `puma.rb` configuration:
+
+```ruby
+plugin :jsbundling if ENV.fetch("RAILS_ENV", "development") == "development"
+```
+
+and then running `rails server` (or just `puma`) will run `bin/rails javascript:watch` process in the background.
 
 ## License
 

--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
-js: yarn build --watch
+js: bin/rails javascript:watch

--- a/lib/install/bun/Procfile.dev
+++ b/lib/install/bun/Procfile.dev
@@ -1,2 +1,2 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
-js: bun run build --watch
+js: bin/rails javascript:watch

--- a/lib/install/bun/install.rb
+++ b/lib/install/bun/install.rb
@@ -3,7 +3,7 @@ require 'json'
 apply "#{__dir__}/../install.rb"
 
 if Rails.root.join("Procfile.dev").exist?
-  append_to_file "Procfile.dev", "js: bun run build --watch\n"
+  append_to_file "Procfile.dev", "js: bin/rails javascript:watch\n"
 else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"

--- a/lib/install/install_procfile.rb
+++ b/lib/install/install_procfile.rb
@@ -1,5 +1,5 @@
 if Rails.root.join("Procfile.dev").exist?
-  append_to_file "Procfile.dev", "js: yarn build --watch\n"
+  append_to_file "Procfile.dev", "js: bin/rails javascript:watch\n"
 else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"

--- a/lib/puma/plugin/jsbundling.rb
+++ b/lib/puma/plugin/jsbundling.rb
@@ -1,0 +1,75 @@
+require "puma/plugin"
+
+Puma::Plugin.create do
+  attr_reader :puma_pid, :jsbundling_pid, :log_writer
+
+  def start(launcher)
+    @log_writer = launcher.log_writer
+    @puma_pid = $$
+    @jsbundling_pid = fork do
+      Thread.new { monitor_puma }
+      # Using IO.popen(command, 'r+') will avoid watch_command read from $stdin.
+      # If we use system(*command) instead, IRB and Debug can't read from $stdin
+      # correctly bacause some keystrokes will be taken by watch_command.
+      begin
+        IO.popen(['bin/rails', 'javascript:watch'], 'r+') do |io|
+          IO.copy_stream(io, $stdout)
+        end
+      rescue Interrupt
+      end
+    end
+
+    if Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new("7")
+      launcher.events.after_stopped { stop_jsbundling }
+    else
+      launcher.events.on_stopped { stop_jsbundling }
+    end
+
+    in_background do
+      monitor_jsbundling
+    end
+  end
+
+  private
+    def stop_jsbundling
+      Process.waitpid(jsbundling_pid, Process::WNOHANG)
+      log "Stopping jsbundling..."
+      Process.kill(:INT, jsbundling_pid) if jsbundling_pid
+      Process.wait(jsbundling_pid)
+    rescue Errno::ECHILD, Errno::ESRCH
+    end
+
+    def monitor_puma
+      monitor(:puma_dead?, "Detected Puma has gone away, stopping jsbundling...")
+    end
+
+    def monitor_jsbundling
+      monitor(:jsbundling_dead?, "Detected jsbundling has gone away, stopping Puma...")
+    end
+
+    def monitor(process_dead, message)
+      loop do
+        if send(process_dead)
+          log message
+          Process.kill(:INT, $$)
+          break
+        end
+        sleep 2
+      end
+    end
+
+    def jsbundling_dead?
+      Process.waitpid(jsbundling_pid, Process::WNOHANG)
+      false
+    rescue Errno::ECHILD, Errno::ESRCH
+      true
+    end
+
+    def puma_dead?
+      Process.ppid != puma_pid
+    end
+
+    def log(...)
+      log_writer.log(...)
+    end
+end

--- a/lib/tasks/jsbundling/build.rake
+++ b/lib/tasks/jsbundling/build.rake
@@ -16,6 +16,16 @@ namespace :javascript do
   end
 
   build_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
+
+  desc "Build and watch your JavaScript bundle"
+  watch_task = task :watch do
+    command = Jsbundling::Tasks.watch_command
+    unless system(command)
+      raise "jsbundling-rails: Command watch failed, ensure `#{command}` runs without errors"
+    end
+  end
+
+  watch_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
 end
 
 module Jsbundling
@@ -40,6 +50,10 @@ module Jsbundling
       when :npm then "npm run build"
       else raise "jsbundling-rails: No suitable tool found for building JavaScript"
       end
+    end
+
+    def watch_command
+      "#{build_command} --watch"
     end
 
     def tool

--- a/test/bun_installer_test.rb
+++ b/test/bun_installer_test.rb
@@ -19,7 +19,7 @@ class BunInstallerTest < ActiveSupport::TestCase
 
       File.read("Procfile.dev").tap do |procfile|
         assert_match "pre: existing", procfile
-        assert_match "js: bun run build --watch", procfile
+        assert_match "js: bin/rails javascript:watch", procfile
       end
 
       JSON.load_file("package.json").tap do |package_json|
@@ -40,7 +40,7 @@ class BunInstallerTest < ActiveSupport::TestCase
       end
 
       File.read("Procfile.dev").tap do |procfile|
-        assert_match "js: bun run build --watch", procfile
+        assert_match "js: bin/rails javascript:watch", procfile
       end
 
       assert_match "STUBBED gem install foreman", out

--- a/test/esbuild_installer_test.rb
+++ b/test/esbuild_installer_test.rb
@@ -10,7 +10,7 @@ class EsbuildInstallerTest < ActiveSupport::TestCase
       out, _err = run_installer
 
       File.read("Procfile.dev").tap do |procfile|
-        assert_match "js: yarn build --watch", procfile
+        assert_match "js: bin/rails javascript:watch", procfile
       end
 
       assert_match "STUBBED gem install foreman", out

--- a/test/rollup_installer_test.rb
+++ b/test/rollup_installer_test.rb
@@ -10,7 +10,7 @@ class RollupInstallerTest < ActiveSupport::TestCase
       out, _err = run_installer
 
       File.read("Procfile.dev").tap do |procfile|
-        assert_match "js: yarn build --watch", procfile
+        assert_match "js: bin/rails javascript:watch", procfile
       end
 
       assert_match "STUBBED gem install foreman", out

--- a/test/webpack_installer_test.rb
+++ b/test/webpack_installer_test.rb
@@ -10,7 +10,7 @@ class WebpackInstallerTest < ActiveSupport::TestCase
       out, _err = run_installer
 
       File.read("Procfile.dev").tap do |procfile|
-        assert_match "js: yarn build --watch", procfile
+        assert_match "js: bin/rails javascript:watch", procfile
       end
 
       assert_match "STUBBED gem install foreman", out


### PR DESCRIPTION
Drawing inspiration from [tailwindcss-rails][] and its `tailwindcss:watch` Rails task, this commit introduces a `javascript:watch` task to extend the existing `javascript:build` task by passing `--watch`.

In addition to the new `javascript:watch` task, this commit also introduces support for a `:jsbundling` [Puma Plugin][] (also drawing inspiration from the [`:tailwindcss` plugin][tailwindcss-plugin]). Support for a Puma Plugin enables local development environments to manage a `bin/rails javascript:watch` process without the need for `bin/dev` or a `Procfile.dev` entry (for example, with [puma-dev][]).

[tailwindcss-rails]: https://github.com/rails/tailwindcss-rails
[Puma Plugin]: https://github.com/puma/puma?tab=readme-ov-file#plugins
[tailwindcss-plugin]: https://github.com/rails/tailwindcss-rails/blob/v4.4.0/lib/puma/plugin/tailwindcss.rb
[puma-dev]: https://github.com/puma/puma-dev