### PR TITLE
CI: Add Ruby 4.0 to CI Matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
         gemfile:
           - gemfiles/rails_6_1.gemfile
           - gemfiles/rails_7_0.gemfile
@@ -24,7 +25,11 @@ jobs:
             gemfile: gemfiles/rails_6_1.gemfile
           - ruby-version: "3.4"
             gemfile: gemfiles/rails_6_1.gemfile
+          - ruby-version: "4.0"
+            gemfile: gemfiles/rails_6_1.gemfile
           - ruby-version: "3.4"
+            gemfile: gemfiles/rails_7_0.gemfile
+          - ruby-version: "4.0"
             gemfile: gemfiles/rails_7_0.gemfile
           - ruby-version: "3.1"
             gemfile: gemfiles/rails_8_0.gemfile
@@ -43,7 +48,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Remove Gemfile lock
         run: |

--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,11 @@
-RUBY_MAJOR_VERSION, RUBY_MINOR_VERSION, _ = RUBY_VERSION.split(".").map(&:to_i)
-
-# run on ruby <= 3.2
-if RUBY_MAJOR_VERSION == 3 && RUBY_MINOR_VERSION <= 2
+if RUBY_VERSION <= "3.2"
   appraise "rails_6_1" do
     gem "rails", "~> 6.1.0"
     gem 'concurrent-ruby', '<= 1.3.4'
   end
 end
 
-# run on ruby <= 3.3
-if RUBY_MAJOR_VERSION == 3 && RUBY_MINOR_VERSION <= 3
+if RUBY_VERSION <= "3.3"
   appraise "rails_7_0" do
     gem "rails", "~> 7.0.0"
     gem 'concurrent-ruby', '<= 1.3.4'
@@ -27,8 +23,7 @@ appraise "rails_7_2" do
   gem "propshaft"
 end
 
-# run on ruby >= 3.1
-if RUBY_MAJOR_VERSION >= 3 && RUBY_MINOR_VERSION > 1
+if RUBY_VERSION >= "3.2"
   appraise "rails_8_0" do
     gem "rails", "~> 8.0.0"
     gem "propshaft"
@@ -38,7 +33,9 @@ if RUBY_MAJOR_VERSION >= 3 && RUBY_MINOR_VERSION > 1
     gem "rails", "~> 8.1.0"
     gem "propshaft"
   end
+end
 
+if RUBY_VERSION >= "3.3"
   appraise "rails_main" do
     gem "rails", github: "rails/rails", branch: "main"
     gem "propshaft"


### PR DESCRIPTION
This Pull Request adds Ruby 4.0 to the CI Matrix.

It also includes the following fixes:
- Fix Appraisal configurations for supported Ruby versions.
- Update actions/checkout from 5 to 7

~~Additionally, it removes Gemfile lock files to make maintenance easier.~~

> By the way, are the `Gemfile.lock` file and the `gemfiles/*.lock` files actually necessary for this repository? Since they seem to be deleted in every CI run, if they're not needed, I'm thinking of creating a Pull Request to remove the `.lock` files.
> 
> * https://github.com/rails/jsbundling-rails/blob/a29703e36bdf9c91716ef210d17d32081800d75d/.github/workflows/ci.yml#L48-L50

- See #222
